### PR TITLE
Fix comment shortening with long words

### DIFF
--- a/_fixtures/comments.go
+++ b/_fixtures/comments.go
@@ -22,6 +22,14 @@ func testFunc() {
 		if i > 5 {
 			// This is a another really, really long comment on a single line. We should try to break it up if possible because it's longer than 100 chars.
 			fmt.Print("hello")
+
+			// These are comments like the ones in https://github.com/segmentio/golines/issues/9
+			//
+			// Documentation: https://swagger.io/docs/specification/authentication/bearer-authentication/more/more/more/more/more
+			//
+			// More documentation:
+			// https://swagger.io/docs/specification/authentication/bearer-authentication/more/more/more/more/more
+			fmt.Println("Hello again")
 		}
 	}
 }

--- a/_fixtures/comments__exp.go
+++ b/_fixtures/comments__exp.go
@@ -24,6 +24,15 @@ func testFunc() {
 			// This is a another really, really long comment on a single line. We should try to break
 			// it up if possible because it's longer than 100 chars.
 			fmt.Print("hello")
+
+			// These are comments like the ones in https://github.com/segmentio/golines/issues/9
+			//
+			// Documentation:
+			// https://swagger.io/docs/specification/authentication/bearer-authentication/more/more/more/more/more
+			//
+			// More documentation:
+			// https://swagger.io/docs/specification/authentication/bearer-authentication/more/more/more/more/more
+			fmt.Println("Hello again")
 		}
 	}
 }

--- a/shortener.go
+++ b/shortener.go
@@ -293,7 +293,7 @@ func (s *Shortener) shortenCommentsFunc(contents []byte) []byte {
 			// Take the words in the comment and spread them out
 			// across multiple lines.
 			for _, word := range words {
-				if currLineLen+1+len(word) > maxCommentLen {
+				if currLineLen > 0 && currLineLen+1+len(word) > maxCommentLen {
 					cleanedLines = append(
 						cleanedLines,
 						fmt.Sprintf(


### PR DESCRIPTION
## Description
As reported in https://github.com/segmentio/golines/issues/9, shortening a comment containing a word that's longer than the configured maximum length can lead to an extraneous, blank comment line in the output. This change fixes this by checking whether there are words to emit before outputting a new comment line.