### PR TITLE
Fix comment shortening

### DIFF
--- a/_fixtures/comments.go
+++ b/_fixtures/comments.go
@@ -3,7 +3,7 @@ package fixtures
 import "fmt"
 
 // Short prefix
-// This is a really, really long comment on a single line. We should try to break it up if possible because it's longer than 100 chars.
+// This is a really, really long comment on a single line. We should try to break it up if possible because it's longer than 100 chars. In fact, it's so long that it should probably be on three lines instead of two. Wow, so long!!
 // Short suffix
 //
 

--- a/_fixtures/comments__exp.go
+++ b/_fixtures/comments__exp.go
@@ -4,7 +4,8 @@ import "fmt"
 
 // Short prefix
 // This is a really, really long comment on a single line. We should try to break it up if possible
-// because it's longer than 100 chars.
+// because it's longer than 100 chars. In fact, it's so long that it should probably be on three
+// lines instead of two. Wow, so long!!
 // Short suffix
 //
 
@@ -21,8 +22,8 @@ import "fmt"
 func testFunc() {
 	for i := 0; i < 10; i++ {
 		if i > 5 {
-			// This is a another really, really long comment on a single line. We should try to break
-			// it up if possible because it's longer than 100 chars.
+			// This is a another really, really long comment on a single line. We should try to
+			// break it up if possible because it's longer than 100 chars.
 			fmt.Print("hello")
 
 			// These are comments like the ones in https://github.com/segmentio/golines/issues/9

--- a/_fixtures/end_to_end__exp.go
+++ b/_fixtures/end_to_end__exp.go
@@ -85,8 +85,8 @@ func longLine(
 
 	fmt.Println(z)
 
-	// This is a really long comment on an indented line. Do you think we can split it up or should we
-	// just leave it as is?
+	// This is a really long comment on an indented line. Do you think we can split it up or should
+	// we just leave it as is?
 	if argument4 == "5" {
 		return "", fmt.Errorf(
 			"a very long query with ID %d failed. Check Query History in AWS UI",

--- a/shortener.go
+++ b/shortener.go
@@ -282,7 +282,7 @@ func (s *Shortener) shortenCommentsFunc(contents []byte) []byte {
 			// Try splitting up this comment line
 			start := strings.Index(line, "//")
 			prefix := line[0:(start + 2)]
-			maxCommentLen := s.config.MaxLen - s.lineLen(prefix) + 1
+			maxCommentLen := s.config.MaxLen - s.lineLen(prefix) - 1
 
 			trimmedLine := strings.Trim(line[(start+2):], " ")
 			words := strings.Split(trimmedLine, " ")


### PR DESCRIPTION
## Description
This change fixes a small bug in comment handling that can cause shortened comments to be slightly longer than the configured maximum length.