### PR TITLE
Misc. struct tag alignment improvements

### DIFF
--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -3,10 +3,12 @@ package fixtures
 type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
+	// Field6 example adapted from https://github.com/segmentio/golines/issues/15.
 	ALongField2 string `json:"long_field2" info:"something else" tag:"a really long tag that extends us beyond 100 chars"`
 	Field3      string `json:"field3" info:"third thing"`
 	Field4      string `json:"field3" tag:"something"`
 	Field5      string `tag:"something else" tag:"something"`
+	Field6      string `json:"somevalue" info:"http://username:password@example.com:1234"`
 }
 
 type MyStruct2 struct {

--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -9,7 +9,7 @@ type MyStruct struct {
 	ALongField2 string `json:"long_field2" info:"something else" tag:"a really long tag that extends us beyond 100 chars"`
 	Field3      string `json:"field3" info:"third thing"`
 	Field4      string `json:"field3" tag:"something"`
-	Field5      string `tag:"something else" tag:"something"`
+	Field5      int    `tag:"something else" tag:"something"`
 	Field6      string `json:"somevalue" info:"http://username:password@example.com:1234"`
 }
 
@@ -17,9 +17,9 @@ type MyStruct2 struct {
 	Field1 string
 
 	ALongField2 string
-	Field3      string `json:"field3"`
-	Field4      string
-	Field5      string `json:"something else"`
+	Field3      string            `json:"field3" info:"here"`
+	Field5      map[string]string `json:"something else"`
+	MyStruct    `json:"mystruct tag" info2:"here"`
 }
 
 func myfunc() {
@@ -32,4 +32,35 @@ func myfunc() {
 
 	s2 := Struct3{}
 	fmt.Println(s, s2)
+}
+
+type Struct4 struct {
+	Field1   []int `json:"field"`
+	MyStruct `json:"field"`
+}
+
+type Struct5 struct {
+	Field1   *int `json:"field"`
+	MyStruct `json:"field"`
+}
+
+type Struct6 struct {
+	Field1   chan<- int `json:"field"`
+	MyStruct `json:"field"`
+}
+
+type Struct7 struct {
+	Field1   <-chan int `json:"field"`
+	Field2   string     `json:"field"`
+	MyStruct `json:"field"`
+}
+
+type Struct8 struct {
+	Field1   chan int `json:"field"`
+	MyStruct `json:"field"`
+}
+
+type Struct9 struct {
+	Field1   MyStruct `json:"field"`
+	MyStruct `json:"field"`
 }

--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "fmt"
+
 type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
@@ -18,4 +20,16 @@ type MyStruct2 struct {
 	Field3      string `json:"field3"`
 	Field4      string
 	Field5      string `json:"something else"`
+}
+
+func myfunc() {
+	s := 4
+
+	type Struct3 struct {
+		Field1 string `json:"field1" info:"something"`
+		Field2 string `json:"field2 long value" info:"third thing"`
+	}
+
+	s2 := Struct3{}
+	fmt.Println(s, s2)
 }

--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -60,11 +60,15 @@ type Struct8 struct {
 	MyStruct `json:"field"`
 }
 
+// Formatting of tags after nameless field isn't handled perfectly
 type Struct9 struct {
+	Field0   int      `json:"field"`
 	Field1   MyStruct `json:"field"`
 	MyStruct `json:"field"`
+	Field2   string `json:"field"`
 }
 
+// Width of function types isn't supported, so MyStruct tags will not be aligned
 type Struct10 struct {
 	Field1   func(int, int) string `json:"field" info:"value"`
 	Field2   string                `info:"value2"`

--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -60,7 +60,7 @@ type Struct8 struct {
 	MyStruct `json:"field"`
 }
 
-// Formatting of tags after nameless field isn't handled perfectly
+// Formatting of tags after embedded field isn't handled perfectly
 type Struct9 struct {
 	Field0   int      `json:"field"`
 	Field1   MyStruct `json:"field"`

--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -64,3 +64,9 @@ type Struct9 struct {
 	Field1   MyStruct `json:"field"`
 	MyStruct `json:"field"`
 }
+
+type Struct10 struct {
+	Field1   func(int, int) string `json:"field" info:"value"`
+	Field2   string                `info:"value2"`
+	MyStruct `json:"field"   info:"value3"`
+}

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -60,7 +60,7 @@ type Struct8 struct {
 	MyStruct `         json:"field"`
 }
 
-// Formatting of tags after nameless field isn't handled perfectly
+// Formatting of tags after embedded field isn't handled perfectly
 type Struct9 struct {
 	Field0   int      `json:"field"`
 	Field1   MyStruct `json:"field"`

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -1,5 +1,7 @@
 package fixtures
 
+import "fmt"
+
 type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
@@ -18,4 +20,16 @@ type MyStruct2 struct {
 	Field3      string `json:"field3"`
 	Field4      string
 	Field5      string `json:"something else"`
+}
+
+func myfunc() {
+	s := 4
+
+	type Struct3 struct {
+		Field1 string `json:"field1"            info:"something"`
+		Field2 string `json:"field2 long value" info:"third thing"`
+	}
+
+	s2 := Struct3{}
+	fmt.Println(s, s2)
 }

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -64,3 +64,9 @@ type Struct9 struct {
 	Field1   MyStruct `json:"field"`
 	MyStruct `         json:"field"`
 }
+
+type Struct10 struct {
+	Field1   func(int, int) string `json:"field" info:"value"`
+	Field2   string                `             info:"value2"`
+	MyStruct `json:"field" info:"value3"`
+}

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -60,11 +60,15 @@ type Struct8 struct {
 	MyStruct `         json:"field"`
 }
 
+// Formatting of tags after nameless field isn't handled perfectly
 type Struct9 struct {
+	Field0   int      `json:"field"`
 	Field1   MyStruct `json:"field"`
 	MyStruct `         json:"field"`
+	Field2   string `json:"field"`
 }
 
+// Width of function types isn't supported, so MyStruct tags will not be aligned
 type Struct10 struct {
 	Field1   func(int, int) string `json:"field" info:"value"`
 	Field2   string                `             info:"value2"`

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -9,7 +9,7 @@ type MyStruct struct {
 	ALongField2 string `json:"long_field2" info:"something else"                            tag:"a really long tag that extends us beyond 100 chars"`
 	Field3      string `json:"field3"      info:"third thing"`
 	Field4      string `json:"field3"                                                       tag:"something"`
-	Field5      string `                                                                    tag:"something else"`
+	Field5      int    `                                                                    tag:"something else"`
 	Field6      string `json:"somevalue"   info:"http://username:password@example.com:1234"`
 }
 
@@ -17,9 +17,9 @@ type MyStruct2 struct {
 	Field1 string
 
 	ALongField2 string
-	Field3      string `json:"field3"`
-	Field4      string
-	Field5      string `json:"something else"`
+	Field3      string            `json:"field3"         info:"here"`
+	Field5      map[string]string `json:"something else"`
+	MyStruct    `                  json:"mystruct tag"               info2:"here"`
 }
 
 func myfunc() {
@@ -32,4 +32,35 @@ func myfunc() {
 
 	s2 := Struct3{}
 	fmt.Println(s, s2)
+}
+
+type Struct4 struct {
+	Field1   []int `json:"field"`
+	MyStruct `      json:"field"`
+}
+
+type Struct5 struct {
+	Field1   *int `json:"field"`
+	MyStruct `     json:"field"`
+}
+
+type Struct6 struct {
+	Field1   chan<- int `json:"field"`
+	MyStruct `           json:"field"`
+}
+
+type Struct7 struct {
+	Field1   <-chan int `json:"field"`
+	Field2   string     `json:"field"`
+	MyStruct `           json:"field"`
+}
+
+type Struct8 struct {
+	Field1   chan int `json:"field"`
+	MyStruct `         json:"field"`
+}
+
+type Struct9 struct {
+	Field1   MyStruct `json:"field"`
+	MyStruct `         json:"field"`
 }

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -3,10 +3,12 @@ package fixtures
 type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
-	ALongField2 string `json:"long_field2" info:"something else" tag:"a really long tag that extends us beyond 100 chars"`
+	// Field6 example adapted from https://github.com/segmentio/golines/issues/15.
+	ALongField2 string `json:"long_field2" info:"something else"                            tag:"a really long tag that extends us beyond 100 chars"`
 	Field3      string `json:"field3"      info:"third thing"`
-	Field4      string `json:"field3"                            tag:"something"`
-	Field5      string `                                         tag:"something else"`
+	Field4      string `json:"field3"                                                       tag:"something"`
+	Field5      string `                                                                    tag:"something else"`
+	Field6      string `json:"somevalue"   info:"http://username:password@example.com:1234"`
 }
 
 type MyStruct2 struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/dave/dst v0.23.1
 	github.com/dave/jennifer v1.2.0
+	github.com/fatih/structtag v1.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/shortener.go
+++ b/shortener.go
@@ -453,6 +453,8 @@ func (s *Shortener) formatStmt(stmt dst.Stmt) {
 		for _, stmt := range st.Body {
 			s.formatStmt(stmt)
 		}
+	case *dst.DeclStmt:
+		s.formatDecl(st.Decl)
 	case *dst.DeferStmt:
 		s.formatExpr(st.Call, shouldShorten)
 	case *dst.ExprStmt:

--- a/tags.go
+++ b/tags.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
+	"github.com/fatih/structtag"
 )
 
-var tagKeyRegexp = regexp.MustCompile("([a-zA-Z0-9_-]+):")
 var structTagRegexp = regexp.MustCompile("`([ ]*[a-zA-Z0-9_-]+:\".*\"[ ]*){2,}`")
 
 // HasMultiKeyTags returns whether the given lines have a multikey struct line.
@@ -73,13 +73,16 @@ func alignTags(fields []*dst.Field) {
 		}
 
 		tagValue = tagValue[1 : len(tagValue)-1]
+
+		subTags, err := structtag.Parse(string(tagValue))
+		if err != nil {
+			return
+		}
+		subTagKeys := subTags.Keys()
+
 		structTag := reflect.StructTag(tagValue)
 
-		keyMatches := tagKeyRegexp.FindAllStringSubmatch(tagValue, -1)
-
-		for _, keyMatch := range keyMatches {
-			key := keyMatch[1]
-
+		for _, key := range subTagKeys {
 			value := structTag.Get(key)
 
 			// Tag is key, value, and some extra chars (two quotes + one colon)

--- a/tags.go
+++ b/tags.go
@@ -71,7 +71,6 @@ func alignTags(fields []*dst.Field) {
 		if tagValue[0] != '`' || tagValue[len(tagValue)-1] != '`' {
 			continue
 		}
-
 		tagValue = tagValue[1 : len(tagValue)-1]
 
 		subTags, err := structtag.Parse(string(tagValue))

--- a/tags.go
+++ b/tags.go
@@ -86,7 +86,7 @@ func alignTags(fields []*dst.Field) {
 		}
 		tagValue = tagValue[1 : len(tagValue)-1]
 
-		subTags, err := structtag.Parse(string(tagValue))
+		subTags, err := structtag.Parse(tagValue)
 		if err != nil {
 			return
 		}

--- a/tags.go
+++ b/tags.go
@@ -59,8 +59,21 @@ func alignTags(fields []*dst.Field) {
 	tagKeys := []string{}
 	tagKVs := make([]map[string]string, len(fields))
 
+	maxTypeWidth := 0
+	invalidWidths := false
+
 	// First, scan over all field tags so that we can understand their values and widths
 	for f, field := range fields {
+		if len(field.Names) > 0 {
+			typeWidth, err := getWidth(field.Type)
+			if err != nil {
+				// We couldn't figure out the proper width of this field
+				invalidWidths = true
+			} else if typeWidth > maxTypeWidth {
+				maxTypeWidth = typeWidth
+			}
+		}
+
 		if field.Tag == nil {
 			continue
 		}
@@ -110,6 +123,15 @@ func alignTags(fields []*dst.Field) {
 
 		tagComponents := []string{}
 
+		if len(field.Names) == 0 && maxTypeWidth > 0 && !invalidWidths {
+			// Add extra spacing at beginning so that tag aligns with named field tags
+			tagComponents = append(tagComponents, "")
+
+			for i := 0; i < maxTypeWidth; i++ {
+				tagComponents[len(tagComponents)-1] += " "
+			}
+		}
+
 		for _, key := range tagKeys {
 			value, ok := tagKVs[f][key]
 			lenUsed := 0
@@ -121,14 +143,69 @@ func alignTags(fields []*dst.Field) {
 				tagComponents = append(tagComponents, "")
 			}
 
-			lenRemaining := maxTagWidths[key] - lenUsed
+			if len(field.Names) > 0 || !invalidWidths {
+				lenRemaining := maxTagWidths[key] - lenUsed
 
-			for i := 0; i < lenRemaining; i++ {
-				tagComponents[len(tagComponents)-1] += " "
+				for i := 0; i < lenRemaining; i++ {
+					tagComponents[len(tagComponents)-1] += " "
+				}
 			}
 		}
 
 		updatedTagValue := strings.TrimRight(strings.Join(tagComponents, " "), " ")
 		field.Tag.Value = fmt.Sprintf("`%s`", updatedTagValue)
 	}
+}
+
+// getWidth tries to guess the formatted width of a dst node expression. If this isn't (yet)
+// possible, it returns an error.
+func getWidth(node dst.Node) (int, error) {
+	switch n := node.(type) {
+	case *dst.ArrayType:
+		eltWidth, err := getWidth(n.Elt)
+		if err != nil {
+			return 0, err
+		}
+
+		return 2 + eltWidth, nil
+	case *dst.ChanType:
+		valWidth, err := getWidth(n.Value)
+		if err != nil {
+			return 0, err
+		}
+
+		isSend := n.Dir&dst.SEND > 0
+		isRecv := n.Dir&dst.RECV > 0
+
+		if isSend && isRecv {
+			// Channel does not include an arrow
+			return 5 + valWidth, nil
+		}
+
+		// Channel includes an arrow
+		return 7 + valWidth, nil
+	case *dst.Ident:
+		return len(n.Name), nil
+	case *dst.MapType:
+		keyWidth, err := getWidth(n.Key)
+		if err != nil {
+			return 0, err
+		}
+
+		valWidth, err := getWidth(n.Value)
+		if err != nil {
+			return 0, err
+		}
+
+		return 5 + keyWidth + valWidth, nil
+	case *dst.StarExpr:
+		xWidth, err := getWidth(n.X)
+		if err != nil {
+			return 0, err
+		}
+
+		return 1 + xWidth, nil
+	}
+
+	return 0, fmt.Errorf("Could not get width of node %+v", node)
 }


### PR DESCRIPTION
## Description
This change includes several fixes and improvements to the `golines` struct tag alignment logic:

1. Use [fatih/structtag](https://github.com/fatih/structtag) for parsing out tag keys instead of a naive regular expression. The former handles embedded colons and other edge cases a lot better.
2. Perform tag alignment for structs defined inside functions
3. Try to improve tag alignment in case of embedded structs

Note that (3) is still best-effort. See the `struct_tags` fixture for examples that are handled and not handled currently. 