### PR TITLE
Fix formatting for very long binary expressions

### DIFF
--- a/_fixtures/binary_operators.go
+++ b/_fixtures/binary_operators.go
@@ -2,9 +2,9 @@ package fixtures
 
 import (
 	"fmt"
-	"log"
 )
 
 func testBinaryOperators() {
 	z := argument1 + argument2 + fmt.Sprintf("This is a really long statement that should be broken up %s %s %s", argument1, argument2, argument3)
+	y := "hello this is a big string" || "this is a small string" || "the smallest string" || "this is another big string" || "this is an even bigger string >>>"
 }

--- a/_fixtures/binary_operators__exp.go
+++ b/_fixtures/binary_operators__exp.go
@@ -2,7 +2,6 @@ package fixtures
 
 import (
 	"fmt"
-	"log"
 )
 
 func testBinaryOperators() {
@@ -12,4 +11,7 @@ func testBinaryOperators() {
 		argument2,
 		argument3,
 	)
+	y := "hello this is a big string" || "this is a small string" || "the smallest string" ||
+		"this is another big string" ||
+		"this is an even bigger string >>>"
 }

--- a/shortener.go
+++ b/shortener.go
@@ -496,7 +496,11 @@ func (s *Shortener) formatExpr(expr dst.Expr, force bool, isChain bool) {
 	switch e := expr.(type) {
 	case *dst.BinaryExpr:
 		if (e.Op == token.LAND || e.Op == token.LOR) && shouldShorten {
-			e.Y.Decorations().Before = dst.NewLine
+			if e.Y.Decorations().Before == dst.NewLine {
+				s.formatExpr(e.X, force, isChain)
+			} else {
+				e.Y.Decorations().Before = dst.NewLine
+			}
 		} else {
 			s.formatExpr(e.X, shouldShorten, isChain)
 			s.formatExpr(e.Y, shouldShorten, isChain)


### PR DESCRIPTION
### Issue
I found a problem that if we have a long and complex expression, then golines will add a new line only before last operand.
So if you have a code like this:
```
if getBooool1() || getBooool2() || getBooool3() || getBooool4() || getBooool5() || getBooool6() || getBooool7() {
	return "Hey"
}
```
it will become
```
if getBooool1() || getBooool2() || getBooool3() || getBooool4() || getBooool5() || getBooool6() ||
        getBooool7() {
	return "Hey"
}
```

### Solution
My fix is pretty simple. The result will look like this
```
if getBooool1() || getBooool2() || getBooool3() || getBooool4() || getBooool5() ||
        getBooool6() ||
        getBooool7() {
	return "Hey"
}
```
It is not perfect. I would like to see something like this:
```
if getBooool1() || getBooool2() || getBooool3() || getBooool4() || getBooool5() ||
        getBooool6() || getBooool7() {
	return "Hey"
}
```
but this will require much more changes and really big refactoring I think. It is because how complex BinaryExpr are treated by dst