### PR TITLE
Update go to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/segmentio/golines
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.17
         environment:
           GO111MODULE: 'on'
     steps:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://img.shields.io/badge/Go%20Coverage-84%25-brightgreen.svg?longCache=true&style=flat)](https://gocover.io/github.com/segmentio/golines?version=1.13.x)
 
 # golines
+
 Golines is a golang formatter that shortens long lines, in addition to all
 of the formatting fixes done by [`gofmt`](https://golang.org/cmd/gofmt/).
 
@@ -49,7 +50,7 @@ view of a file with very long lines. More example pairs can be found in the
 First, install the tool:
 
 ```
-go get -u github.com/segmentio/golines
+go install github.com/segmentio/golines@latest
 ```
 
 Then, run:

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,31 @@
 module github.com/segmentio/golines
 
-go 1.16
+go 1.17
+
+require (
+	github.com/dave/dst v0.26.2
+	github.com/dave/jennifer v1.2.0
+	github.com/fatih/structtag v1.2.0
+	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
+	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/dave/dst v0.26.2
-	github.com/dave/jennifer v1.2.0
-	github.com/fatih/structtag v1.2.0
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
-	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.4.0
-	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/sys v0.0.0-20191024172528-b4ff53e7a1cb // indirect
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	versionStr = "0.5.0"
+	versionStr = "0.6.0"
 )
 
 var (


### PR DESCRIPTION
## Description
This change updates the project minimum go version to 1.17. It also fixes the installation instructions in the README and bumps the version to `0.0.6`.