### PR TITLE
Fix shortening of inline interface definitions inside function declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ golines [paths to format]
 ```
 
 The paths can be either directories or individual files. If no paths are
-provided, then input is taken from stdin (as with `gofmt`).
+provided, then input is taken from `stdin` (as with `gofmt`).
 
-By default, the results are printed to stdout. To overwrite the existing
+By default, the results are printed to `stdout`. To overwrite the existing
 files in place, use the `-w` flag.
 
 ## Options
@@ -204,7 +204,7 @@ For each input source file, `golines` runs through the following process:
   the newlines around the node and/or its children
 6. Repeat steps 2-5 until no more shortening can be done
 7. Run the base formatter (e.g., `gofmt`) over the results, write these to either
-  stdout or the source file
+  `stdout` or the source file
 
 See [this blog post](https://yolken.net/blog/cleaner-go-code-golines) for more technical details.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ with the `--shorten-comments` flag.
 
 By default, the tool will use [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) as
 the base formatter (if found), otherwise it will revert to `gofmt`. An explicit formatter can be
-set via the `--base-formatter` flag.
+set via the `--base-formatter` flag; the command provided here should accept its input via
+`stdin` and write its output to `stdout`.
 
 #### Generated files
 

--- a/_fixtures/inline_interface.go
+++ b/_fixtures/inline_interface.go
@@ -1,0 +1,10 @@
+package fixtures
+
+// Based on example in https://github.com/segmentio/golines/issues/40
+func CreateEphemeralRecordEvent(ctx interface {
+	string
+	int
+	string
+}, id string, name string, kaid string, districtID string, status string, anotherArg string, aThirdArg string) (*string, error) {
+	return nil, nil
+}

--- a/_fixtures/inline_interface__exp.go
+++ b/_fixtures/inline_interface__exp.go
@@ -1,0 +1,19 @@
+package fixtures
+
+// Based on example in https://github.com/segmentio/golines/issues/40
+func CreateEphemeralRecordEvent(
+	ctx interface {
+		string
+		int
+		string
+	},
+	id string,
+	name string,
+	kaid string,
+	districtID string,
+	status string,
+	anotherArg string,
+	aThirdArg string,
+) (*string, error) {
+	return nil, nil
+}

--- a/annotation.go
+++ b/annotation.go
@@ -35,7 +35,7 @@ func HasAnnotation(node dst.Node) bool {
 }
 
 // HasTailAnnotation determines whether the given AST node has a line length annotation at its
-// end. This is needed to catch long function declarations with inline interface defintions.
+// end. This is needed to catch long function declarations with inline interface definitions.
 func HasTailAnnotation(node dst.Node) bool {
 	endDecorations := node.Decorations().End.All()
 	return len(endDecorations) > 0 &&

--- a/annotation.go
+++ b/annotation.go
@@ -34,6 +34,14 @@ func HasAnnotation(node dst.Node) bool {
 		IsAnnotation(startDecorations[len(startDecorations)-1])
 }
 
+// HasTailAnnotation determines whether the given AST node has a line length annotation at its
+// end. This is needed to catch long function declarations with inline interface defintions.
+func HasTailAnnotation(node dst.Node) bool {
+	endDecorations := node.Decorations().End.All()
+	return len(endDecorations) > 0 &&
+		IsAnnotation(endDecorations[len(endDecorations)-1])
+}
+
 // HasAnnotationRecursive determines whether the given node or one of its children has a
 // golines annotation on it. It's currently implemented for function declarations, fields,
 // call expressions, and selector expressions only.
@@ -51,6 +59,8 @@ func HasAnnotationRecursive(node dst.Node) bool {
 				}
 			}
 		}
+	case *dst.Field:
+		return HasTailAnnotation(n) || HasAnnotationRecursive(n.Type)
 	case *dst.SelectorExpr:
 		return HasAnnotation(n.Sel) || HasAnnotation(n.X)
 	case *dst.CallExpr:
@@ -60,6 +70,12 @@ func HasAnnotationRecursive(node dst.Node) bool {
 
 		for _, arg := range n.Args {
 			if HasAnnotation(arg) {
+				return true
+			}
+		}
+	case *dst.InterfaceType:
+		for _, field := range n.Methods.List {
+			if HasAnnotationRecursive(field) {
 				return true
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	versionStr = "0.6.0"
+	versionStr = "0.7.0"
 )
 
 var (

--- a/shortener.go
+++ b/shortener.go
@@ -389,7 +389,11 @@ func (s *Shortener) formatNode(node dst.Node) {
 func (s *Shortener) formatDecl(decl dst.Decl) {
 	switch d := decl.(type) {
 	case *dst.FuncDecl:
+		log.Debugf("Got function declaration")
+
 		if HasAnnotationRecursive(decl) {
+			log.Debugf("Has annotation recursive")
+
 			if d.Type != nil && d.Type.Params != nil {
 				s.formatFieldList(d.Type.Params)
 			}

--- a/shortener.go
+++ b/shortener.go
@@ -389,11 +389,7 @@ func (s *Shortener) formatNode(node dst.Node) {
 func (s *Shortener) formatDecl(decl dst.Decl) {
 	switch d := decl.(type) {
 	case *dst.FuncDecl:
-		log.Debugf("Got function declaration")
-
 		if HasAnnotationRecursive(decl) {
-			log.Debugf("Has annotation recursive")
-
 			if d.Type != nil && d.Type.Params != nil {
 				s.formatFieldList(d.Type.Params)
 			}


### PR DESCRIPTION
## Description
This change fixes the issue described in https://github.com/segmentio/golines/issues/40. It also improves the documentation around custom formatter interfaces as discussed in https://github.com/segmentio/golines/issues/44.

## Testing
Testing completed successfully via adding a new fixture, verifying that the shortened version looked as expected.