### PR TITLE
Improve comment reflow

### DIFF
--- a/_fixtures/comments.go
+++ b/_fixtures/comments.go
@@ -7,6 +7,9 @@ import "fmt"
 // Short suffix
 //
 
+// This comment contains multiple contiguous lines which are greater than the target maximum line length.
+// The expected result is a sequence of shortened (reflown) lines without preserving the position of line breaks.
+
 // Another comment
 
 /*

--- a/_fixtures/comments__exp.go
+++ b/_fixtures/comments__exp.go
@@ -9,6 +9,10 @@ import "fmt"
 // Short suffix
 //
 
+// This comment contains multiple contiguous lines which are greater than the target maximum line
+// length. The expected result is a sequence of shortened (reflown) lines without preserving the
+// position of line breaks.
+
 // Another comment
 
 /*


### PR DESCRIPTION
For a comment containing multiple contiguous long lines, the current
behavior is to preserve the line breaks in between them.

	$ cat x.go
	package main

	// This comment contains multiple contiguous lines which are greater than the target maximum line length.
	// The expected result is a sequence of shortened (reflown) lines without preserving the position of line breaks.

	$ golines --shorten-comments x.go
	package main

	// This comment contains multiple contiguous lines which are greater than the target maximum line
	// length.
	// The expected result is a sequence of shortened (reflown) lines without preserving the position of
	// line breaks.

The modified behavior is a sequence of shortened (reflown) lines without
preserving the position of line breaks.

	$ golines --shorten-comments x.go
	package main

	// This comment contains multiple contiguous lines which are greater than the target maximum line
	// length. The expected result is a sequence of shortened (reflown) lines without preserving the
	// position of line breaks.

The comment lines which are shorter than the target maximum line length
are not reflown.