### PR TITLE
Don't add colors unless output goes to a terminal

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -16,6 +16,7 @@ import (
 // user experience.
 const pyTemplate = `
 import difflib
+import sys
 
 class bcolors:
     OKBLUE = '\033[94m'
@@ -37,7 +38,9 @@ def main():
 
     for line in diff:
         line = line.rstrip()
-        if line.startswith('+'):
+        if not sys.stdout.isatty() and len(line) > 0:
+            print(line)
+        elif line.startswith('+'):
             print(bcolors.OKGREEN + line + bcolors.ENDC)
         elif line.startswith('-'):
             print(bcolors.FAIL + line + bcolors.ENDC)


### PR DESCRIPTION
The embedded python script currently adds color codes even if the user
redirects output to a file (e.g., `golines --dry-run file.go > diff.txt`).

This updated version uses `isatty` to prevent that.