### PR TITLE
feat: adds pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: golines
   name: golines
-  description:  A golang formatter that fixes long lines.
+  description: A golang formatter that fixes long lines.
   entry: golines . -w
   types: [go]
   language: golang

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: golines
+  name: golines
+  description:  A golang formatter that fixes long lines.
+  entry: golines . -w
+  types: [go]
+  language: golang
+  pass_filenames: false


### PR DESCRIPTION
Adds [pre-commit](https://pre-commit.com/) hook config, to be able to run it as a git hook and automatically sort all the long lines before commit.