### PR TITLE
Update README with version-specific installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ release.
 
 ## Usage
 
-First, install the tool:
+First, install the tool. If you're using golang 1.18, run:
 
 ```
 go install github.com/segmentio/golines@latest
+```
+
+Otherwise, for older golang versions, run:
+
+```
+go install github.com/segmentio/golines@v0.9.0
 ```
 
 Then, run:


### PR DESCRIPTION
## Description
This change updates the README to avoid confusion around installation errors for golang versions < 1.18.