### PR TITLE
Fix len on multi-byte characters

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -98,7 +98,7 @@ func alignTags(fields []*dst.Field) {
 			value := structTag.Get(key)
 
 			// Tag is key, value, and some extra chars (two quotes + one colon)
-			width := len(key) + len(value) + 3
+			width := len(key) + tagValueLen(value) + 3
 
 			if _, ok := maxTagWidths[key]; !ok {
 				maxTagWidths[key] = width
@@ -155,6 +155,12 @@ func alignTags(fields []*dst.Field) {
 		updatedTagValue := strings.TrimRight(strings.Join(tagComponents, " "), " ")
 		field.Tag.Value = fmt.Sprintf("`%s`", updatedTagValue)
 	}
+}
+
+// get real tag value's length, fix multi-byte character's length, such as `ï`
+// or `中文`
+func tagValueLen(s string) int {
+	return len([]rune(s))
 }
 
 // getWidth tries to guess the formatted width of a dst node expression. If this isn't (yet)


### PR DESCRIPTION
Before
```go
type Diacritics struct {
    A string `foo:"ä" json:"a"`
    E string `foo:"e"  json:"e"`
    I string `foo:"ï" json:"i"`
    O string `foo:"o"  json:"o"`
    U string `foo:"ü" json:"u"`
}
```

After
```go
type Diacritics struct {
	A string `foo:"ä" json:"a"`
	E string `foo:"e" json:"e"`
	I string `foo:"ï" json:"i"`
	O string `foo:"o" json:"o"`
	U string `foo:"ü" json:"u"`
}
```