### PR TITLE
Update fixtures and bump version

### DIFF
--- a/_fixtures/struct_tags.go
+++ b/_fixtures/struct_tags.go
@@ -6,9 +6,9 @@ type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
 	// Field6 example adapted from https://github.com/segmentio/golines/issues/15.
-	ALongField2 string `json:"long_field2" info:"something else" tag:"a really long tag that extends us beyond 100 chars"`
-	Field3      string `json:"field3" info:"third thing"`
-	Field4      string `json:"field3" tag:"something"`
+	ALongField2 string `json:"long_field2 ãï" info:"something else ãï" tag:"a really long tag that extends us beyond 100 chars"`
+	Field3      string `json:"field3" info:"ãï third thing"`
+	Field4      string `json:"field3" tag:"ãï something"`
 	Field5      int    `tag:"something else" tag:"something"`
 	Field6      string `json:"somevalue" info:"http://username:password@example.com:1234"`
 }

--- a/_fixtures/struct_tags__exp.go
+++ b/_fixtures/struct_tags__exp.go
@@ -6,11 +6,11 @@ type MyStruct struct {
 	Field1 string `json:"field1" info:"something"`
 
 	// Field6 example adapted from https://github.com/segmentio/golines/issues/15.
-	ALongField2 string `json:"long_field2" info:"something else"                            tag:"a really long tag that extends us beyond 100 chars"`
-	Field3      string `json:"field3"      info:"third thing"`
-	Field4      string `json:"field3"                                                       tag:"something"`
-	Field5      int    `                                                                    tag:"something else"`
-	Field6      string `json:"somevalue"   info:"http://username:password@example.com:1234"`
+	ALongField2 string `json:"long_field2 ãï" info:"something else ãï"                         tag:"a really long tag that extends us beyond 100 chars"`
+	Field3      string `json:"field3"         info:"ãï third thing"`
+	Field4      string `json:"field3"                                                          tag:"ãï something"`
+	Field5      int    `                                                                       tag:"something else"`
+	Field6      string `json:"somevalue"      info:"http://username:password@example.com:1234"`
 }
 
 type MyStruct2 struct {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	versionStr = "0.10.0"
+	versionStr = "0.11.0"
 )
 
 var (

--- a/tags.go
+++ b/tags.go
@@ -138,7 +138,7 @@ func alignTags(fields []*dst.Field) {
 
 			if ok {
 				tagComponents = append(tagComponents, fmt.Sprintf("%s:\"%s\"", key, value))
-				lenUsed += len(key) + len(value) + 3
+				lenUsed += len(key) + tagValueLen(value) + 3
 			} else {
 				tagComponents = append(tagComponents, "")
 			}


### PR DESCRIPTION
## Description
This change updates the fixtures to cover https://github.com/segmentio/golines/pull/78. It also bumps the version to cover the changes made in the former change as well as https://github.com/segmentio/golines/pull/77.