### PR TITLE
Update .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,6 @@
 - id: golines
   name: golines
   description: A golang formatter that fixes long lines.
-  entry: golines . -w
+  entry: golines -w
   types: [go]
   language: golang
-  pass_filenames: false


### PR DESCRIPTION
pre-commit hooks should not always run on the current directory - formatters should only run on changed files.