### PR TITLE
Add -jobs option

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ func run() error {
 						}
 
 						if !subInfo.IsDir() && strings.HasSuffix(subPath, ".go") {
-							if *writeOutput && *jobs >= 2 {
+							if (*writeOutput || *listFiles) && *jobs >= 2 {
 								wg.Add(1)
 								worker <- &WorkerProcessRequest{
 									path: subPath,
@@ -231,7 +231,7 @@ func run() error {
 					return err
 				}
 			default:
-				if *writeOutput && *jobs >= 2 {
+				if (*writeOutput || *listFiles) && *jobs >= 2 {
 					wg.Add(1)
 					worker <- &WorkerProcessRequest{
 						path: path,

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime/pprof"
 	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
@@ -70,6 +72,9 @@ var (
 	writeOutput = kingpin.Flag(
 		"write-output",
 		"Write output to source instead of stdout").Short('w').Default("false").Bool()
+	jobs = kingpin.Flag(
+		"jobs",
+		"execute N jobs with -w option").Short('j').Default("1").Int()
 
 	// Args
 	paths = kingpin.Arg(
@@ -112,6 +117,36 @@ func main() {
 	}
 }
 
+type WorkerProcessRequest struct {
+	path string
+}
+
+func startWorker(ctx context.Context, shortener *Shortener, wg *sync.WaitGroup, num int) (requestch chan *WorkerProcessRequest) {
+	requestch = make(chan *WorkerProcessRequest)
+
+	for i := 0; i < num; i++ {
+		go func() {
+			for {
+				select {
+				case req := <-requestch:
+					contents, result, err := processFile(shortener, req.path)
+					if err != nil {
+						log.Fatal(err)
+					}
+					err = handleOutput(req.path, contents, result)
+					if err != nil {
+						log.Fatal(err)
+					}
+					wg.Done()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	return
+}
 func run() error {
 	config := ShortenerConfig{
 		MaxLen:           *maxLen,
@@ -125,6 +160,11 @@ func run() error {
 		ChainSplitDots:   *chainSplitDots,
 	}
 	shortener := NewShortener(config)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg := &sync.WaitGroup{}
+	worker := startWorker(ctx, shortener, wg, *jobs)
 
 	if len(*paths) == 0 {
 		// Read input from stdin
@@ -166,14 +206,21 @@ func run() error {
 						}
 
 						if !subInfo.IsDir() && strings.HasSuffix(subPath, ".go") {
-							// Shorten file and generate output
-							contents, result, err := processFile(shortener, subPath)
-							if err != nil {
-								return err
-							}
-							err = handleOutput(subPath, contents, result)
-							if err != nil {
-								return err
+							if *writeOutput && *jobs >= 2 {
+								wg.Add(1)
+								worker <- &WorkerProcessRequest{
+									path: subPath,
+								}
+							} else {
+								// Shorten file and generate output
+								contents, result, err := processFile(shortener, subPath)
+								if err != nil {
+									return err
+								}
+								err = handleOutput(subPath, contents, result)
+								if err != nil {
+									return err
+								}
 							}
 						}
 
@@ -184,18 +231,26 @@ func run() error {
 					return err
 				}
 			default:
-				// Path is a file
-				contents, result, err := processFile(shortener, path)
-				if err != nil {
-					return err
-				}
-				err = handleOutput(path, contents, result)
-				if err != nil {
-					return err
+				if *writeOutput && *jobs >= 2 {
+					wg.Add(1)
+					worker <- &WorkerProcessRequest{
+						path: path,
+					}
+				} else {
+					// Path is a file
+					contents, result, err := processFile(shortener, path)
+					if err != nil {
+						return err
+					}
+					err = handleOutput(path, contents, result)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
 	}
+	wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
## What's this?

enabled the `-jobs` option for performance enhancement when using the `-w` or `-l` option.

When a number greater than or equal to 2 is assigned to the `-jobs` option, an equivalent number of goroutine workers are launched.
These workers handle code formatting tasks, thereby parallelizing the process and enhancing performance as a result.

The results below demonstrate my use case both without the `-jobs` option and with the `-jobs` option set to 4.
I executed each of the -w or -l options three times in both scenarios.
There was approximately a 30% performance increase.

Cases without specifying `-jobs` option:
```
$ time golines -l ./
golines -l ./  72.06s user 252.78s system 1035% cpu 31.360 total
golines -l ./  68.15s user 232.71s system 1015% cpu 29.613 total
golines -l ./  71.16s user 251.04s system 1041% cpu 30.926 total

$ time golines -w ./
golines -w ./  64.21s user 227.85s system 1045% cpu 27.946 total
golines -w ./  65.72s user 221.50s system 965% cpu 29.762 total
golines -w ./  66.27s user 228.43s system 997% cpu 29.554 total
```

Cases with the `-jobs` option set to 4:
```
$ time ./golines.jobs -j 4 -l ./
./golines.jobs -j 4 -l ./  68.51s user 201.23s system 1403% cpu 19.219 total
./golines.jobs -j 4 -l ./  70.68s user 208.27s system 1380% cpu 20.204 total
./golines.jobs -j 4 -l ./  67.81s user 198.54s system 1406% cpu 18.942 total

$ time ./golines.jobs -j 4 -w ./
./golines.jobs -j 4 -w ./  70.34s user 207.37s system 1400% cpu 19.836 total
./golines.jobs -j 4 -w ./  72.11s user 212.88s system 1410% cpu 20.211 total
./golines.jobs -j 4 -w ./  70.00s user 205.18s system 1364% cpu 20.168 total
```
