### PR TITLE
build: build and release on ubuntu-20.04 for older glibc versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    # we need ubuntu 20.04 because golines needs
+    # to run on hosts with older glibc versions
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,9 @@ permissions:
 jobs:
   golangci:
     name: golines lint
-    runs-on: ubuntu-latest
+    # we need ubuntu 20.04 because golines needs
+    # to run on hosts with older glibc versions
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    # we need ubuntu 20.04 because golines needs
+    # to run on hosts with older glibc versions
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          # we need ubuntu 20.04 because golines needs
+          # to run on hosts with older glibc versions
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
         go:


### PR DESCRIPTION
From the buildkite-agent-golang-1.21 image with golang version 0.12.1 in it:
```
/usr/local/bin/golines --version
/usr/local/bin/golines: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/golines)
/usr/local/bin/golines: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/bin/golines)
```