### PR TITLE
Pre-commit hook: pin goimports and allow customized arguments

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   types: [go]
   language: golang
   pass_filenames: false
+  additional_dependencies: ['golang.org/x/tools/cmd/goimports@v0.17.0']

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 - id: golines
   name: golines
   description: A golang formatter that fixes long lines.
-  entry: golines . -w
+  entry: golines
+  args: [-w, .]
   types: [go]
   language: golang
   pass_filenames: false


### PR DESCRIPTION
Two minor propositions for the pre-commit configuration:

1. Use the `additional_dependencies` option to install `goimports` into the isolated environments that `pre-commit` creates for each hook. This makes the hook independent on a system-wide or `$GOBIN` installation of `goimports`, and allows for a portable configuration of pre-commit checks. The hook then also works, if `goimports` is not already installed on the system where the hook runs.
2. Split the hook's `entry` point from its `args`. This allows users to customise how `golines` is invoked in their local `pre-commit` configuration by overriding `args` (`entry` can't be overridden), e.g.:
```yaml
  - repo: https://github.com/segmentio/golines
    rev: v0.12.2
    hooks:
      - id: golines
        args: [-m 80, -t 2, -w, .]
```