### PR TITLE
Add handling for index expressions

### DIFF
--- a/_fixtures/indexexpr.go
+++ b/_fixtures/indexexpr.go
@@ -1,0 +1,3 @@
+package fixtures
+
+var a = longlistfunc(bigarg, otherbigarg, verylongarg, veryverylongarg, veryveryverylongarg, extremelylongarg)[0]

--- a/_fixtures/indexexpr__exp.go
+++ b/_fixtures/indexexpr__exp.go
@@ -1,0 +1,10 @@
+package fixtures
+
+var a = longlistfunc(
+	bigarg,
+	otherbigarg,
+	verylongarg,
+	veryverylongarg,
+	veryveryverylongarg,
+	extremelylongarg,
+)[0]

--- a/shortener.go
+++ b/shortener.go
@@ -545,6 +545,8 @@ func (s *Shortener) formatExpr(expr dst.Expr, force bool, isChain bool) {
 		if shouldShorten {
 			s.formatFieldList(e.Params)
 		}
+	case *dst.IndexExpr:
+		s.formatExpr(e.X, shouldShorten, isChain)
 	case *dst.InterfaceType:
 		for _, method := range e.Methods.List {
 			if HasAnnotation(method) {


### PR DESCRIPTION
Fixes #128 

Before, long lines like this were not shortened:
```go
var a = longlistfunc(bigarg, otherbigarg, verylongarg, veryverylongarg, veryveryverylongarg, extremelylongarg)[0]
```

I'm new to the codebase so let me know if I've missed anything!