### PR TITLE
Format long lines in struct definitions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,6 @@ builds:
       - arm64
     env:
       - GOAMD64=v3
-    ldflags:
-      - -s -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser 
 
 universal_binaries:
   - replace: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,8 @@ builds:
       - arm64
     env:
       - GOAMD64=v3
+    ldflags:
+      - -s -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser 
 
 universal_binaries:
   - replace: true

--- a/_fixtures/struct_interface.go
+++ b/_fixtures/struct_interface.go
@@ -1,0 +1,15 @@
+package fixtures
+
+type MyStruct struct {
+	i             Int
+	LongInterface interface {
+		SuperLongFunctionName(anArgument string, anotherReallyLongArgument string, superDuperLongArgument string, definitelyTheLongestArgument string) error
+	}
+}
+
+type MyShortStruct struct {
+	s              string
+	ShortInterface interface {
+		SuperShortFunctionName(shortArg string) error
+	}
+}

--- a/_fixtures/struct_interface__exp.go
+++ b/_fixtures/struct_interface__exp.go
@@ -1,0 +1,20 @@
+package fixtures
+
+type MyStruct struct {
+	i             Int
+	LongInterface interface {
+		SuperLongFunctionName(
+			anArgument string,
+			anotherReallyLongArgument string,
+			superDuperLongArgument string,
+			definitelyTheLongestArgument string,
+		) error
+	}
+}
+
+type MyShortStruct struct {
+	s              string
+	ShortInterface interface {
+		SuperShortFunctionName(shortArg string) error
+	}
+}

--- a/annotation.go
+++ b/annotation.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/dave/dst"
+	log "github.com/sirupsen/logrus"
 )
 
 const annotationPrefix = "// __golines:shorten:"
@@ -51,6 +52,12 @@ func HasAnnotationRecursive(node dst.Node) bool {
 	}
 
 	switch n := node.(type) {
+	case *dst.GenDecl:
+		for _, spec := range n.Specs {
+			if HasAnnotationRecursive(spec) {
+				return true
+			}
+		}
 	case *dst.FuncDecl:
 		if n.Type != nil && n.Type.Params != nil {
 			for _, item := range n.Type.Params.List {
@@ -59,8 +66,23 @@ func HasAnnotationRecursive(node dst.Node) bool {
 				}
 			}
 		}
+	case *dst.StructType:
+		return HasAnnotationRecursive(n.Fields)
+	case *dst.FuncType:
+		yes := n.Params != nil && HasAnnotationRecursive(n.Params)
+		yes = yes || (n.TypeParams != nil && HasAnnotationRecursive(n.TypeParams))
+		yes = yes || (n.Results != nil && HasAnnotationRecursive(n.Results))
+		return yes
+	case *dst.TypeSpec:
+		return HasAnnotationRecursive(n.Type)
 	case *dst.Field:
 		return HasTailAnnotation(n) || HasAnnotationRecursive(n.Type)
+	case *dst.FieldList:
+		for _, field := range n.List {
+			if HasAnnotationRecursive(field) {
+				return true
+			}
+		}
 	case *dst.SelectorExpr:
 		return HasAnnotation(n.Sel) || HasAnnotation(n.X)
 	case *dst.CallExpr:
@@ -79,6 +101,8 @@ func HasAnnotationRecursive(node dst.Node) bool {
 				return true
 			}
 		}
+	default:
+		log.Debugf("Couldn't analyze type for annotations: %+v", n)
 	}
 
 	return false

--- a/shortener.go
+++ b/shortener.go
@@ -556,6 +556,11 @@ func (s *Shortener) formatExpr(expr dst.Expr, force bool, isChain bool) {
 	case *dst.SelectorExpr:
 		s.formatExpr(e.X, shouldShorten, isChain)
 	case *dst.StructType:
+		if HasAnnotationRecursive(e) && e.Fields != nil {
+			for _, field := range e.Fields.List {
+				s.formatExpr(field.Type, false, isChain)
+			}
+		}
 		if s.config.ReformatTags {
 			FormatStructTags(e.Fields)
 		}

--- a/tags.go
+++ b/tags.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dave/dst"
 	"github.com/fatih/structtag"
+	log "github.com/sirupsen/logrus"
 )
 
 var structTagRegexp = regexp.MustCompile("`([ ]*[a-zA-Z0-9_-]+:\".*\"[ ]*){2,}`")
@@ -213,5 +214,6 @@ func getWidth(node dst.Node) (int, error) {
 		return 1 + xWidth, nil
 	}
 
+	log.Debugf("Could not get width of node %+v", node)
 	return 0, fmt.Errorf("Could not get width of node %+v", node)
 }


### PR DESCRIPTION
Addresses #126

Adds some additional logic to `HasAnnotationRecursive` to support struct types. Recursively formats struct field elements if they have annotations.

Also adds a couple of debug logs I found useful