### PR TITLE
Format structs that have line breaks

### DIFF
--- a/_fixtures/struct_split.go
+++ b/_fixtures/struct_split.go
@@ -1,5 +1,5 @@
 package fixtures
 
-var _ = &mstypes.Filter{
-	Field: "Opportunities", Operator: mstypes.Operator_OPERATOR_EQUAL, Values: []string{"longclosed"},
+var _ = &mybigtype{
+	arg1: "biglongstring1", arg2: longfunctioncall(param1), arg3: []string{"list1"}, arg4: bigvariable,
 }

--- a/_fixtures/struct_split.go
+++ b/_fixtures/struct_split.go
@@ -1,0 +1,5 @@
+package fixtures
+
+var _ = &mstypes.Filter{
+	Field: "Opportunities", Operator: mstypes.Operator_OPERATOR_EQUAL, Values: []string{"longclosed"},
+}

--- a/_fixtures/struct_split__exp.go
+++ b/_fixtures/struct_split__exp.go
@@ -1,7 +1,8 @@
 package fixtures
 
-var _ = &mstypes.Filter{
-	Field:    "Opportunities",
-	Operator: mstypes.Operator_OPERATOR_EQUAL,
-	Values:   []string{"longclosed"},
+var _ = &mybigtype{
+	arg1: "biglongstring1",
+	arg2: longfunctioncall(param1),
+	arg3: []string{"list1"},
+	arg4: bigvariable,
 }

--- a/_fixtures/struct_split__exp.go
+++ b/_fixtures/struct_split__exp.go
@@ -1,0 +1,7 @@
+package fixtures
+
+var _ = &mstypes.Filter{
+	Field:    "Opportunities",
+	Operator: mstypes.Operator_OPERATOR_EQUAL,
+	Values:   []string{"longclosed"},
+}

--- a/annotation.go
+++ b/annotation.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
 	"github.com/dave/dst"
+	log "github.com/sirupsen/logrus"
 )
 
 const annotationPrefix = "// __golines:shorten:"
@@ -51,6 +53,12 @@ func HasAnnotationRecursive(node dst.Node) bool {
 	}
 
 	switch n := node.(type) {
+	case *dst.CompositeLit:
+		for _, elt := range n.Elts {
+			if HasAnnotationRecursive(elt) {
+				return true
+			}
+		}
 	case *dst.FuncDecl:
 		if n.Type != nil && n.Type.Params != nil {
 			for _, item := range n.Type.Params.List {
@@ -79,6 +87,8 @@ func HasAnnotationRecursive(node dst.Node) bool {
 				return true
 			}
 		}
+	default:
+		log.Debugf("Couldn't analyze type for annotations: %+v", reflect.TypeOf(n))
 	}
 
 	return false

--- a/shortener.go
+++ b/shortener.go
@@ -527,7 +527,7 @@ func (s *Shortener) formatExpr(expr dst.Expr, force bool, isChain bool) {
 			s.formatExpr(e.Fun, shouldShorten, isChain)
 		}
 	case *dst.CompositeLit:
-		if shouldShorten {
+		if shouldShorten || HasAnnotationRecursive(e) {
 			for i, element := range e.Elts {
 				if i == 0 {
 					element.Decorations().Before = dst.NewLine


### PR DESCRIPTION
Fixes #131.

I'm not sure if there could be unintended consequences to checking `HasAnnotationRecursive` when looking at a composite literal. Let me know if I should try a different approach.