### PR TITLE
feat: fix pre-commit config to use pass_filenames

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,6 @@
 - id: golines
   name: golines
   description: A golang formatter that fixes long lines.
-  entry: golines . -w
+  entry: golines -w
   types: [go]
   language: golang
-  pass_filenames: false


### PR DESCRIPTION
Using `pass_filenames: true` (the default) is faster than `golines -w .`, because it runs `golines`on only the files that have changed.
