### PR TITLE
feat: Add option to ignore lines before indentation change

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -72,6 +72,9 @@ var (
 	writeOutput = kingpin.Flag(
 		"write-output",
 		"Write output to source instead of stdout").Short('w').Default("false").Bool()
+	ignoreBeforeIndentChange = kingpin.Flag(
+		"ignore-indent-change",
+		"Ignore line length before indent change").Short('i').Default("false").Bool()
 
 	// Args
 	paths = kingpin.Arg(
@@ -117,15 +120,16 @@ func main() {
 
 func run() error {
 	config := ShortenerConfig{
-		MaxLen:           *maxLen,
-		TabLen:           *tabLen,
-		KeepAnnotations:  *keepAnnotations,
-		ShortenComments:  *shortenComments,
-		ReformatTags:     *reformatTags,
-		IgnoreGenerated:  *ignoreGenerated,
-		DotFile:          *dotFile,
-		BaseFormatterCmd: *baseFormatterCmd,
-		ChainSplitDots:   *chainSplitDots,
+		MaxLen:                   *maxLen,
+		TabLen:                   *tabLen,
+		KeepAnnotations:          *keepAnnotations,
+		ShortenComments:          *shortenComments,
+		ReformatTags:             *reformatTags,
+		IgnoreGenerated:          *ignoreGenerated,
+		DotFile:                  *dotFile,
+		BaseFormatterCmd:         *baseFormatterCmd,
+		ChainSplitDots:           *chainSplitDots,
+		IgnoreBeforeIndentChange: *ignoreBeforeIndentChange,
 	}
 	shortener := NewShortener(config)
 
@@ -258,5 +262,4 @@ func handleOutput(path string, contents []byte, result []byte) error {
 
 	fmt.Print(string(result))
 	return nil
-
 }

--- a/shortener.go
+++ b/shortener.go
@@ -434,7 +434,7 @@ func (s *Shortener) formatStmt(stmt dst.Stmt) {
 			s.formatStmt(stmt)
 		}
 	case *dst.CaseClause:
-		if shouldShorten {
+		if shouldShorten && !s.config.IgnoreBeforeIndentChange {
 			for _, arg := range st.List {
 				arg.Decorations().After = dst.NewLine
 				s.formatExpr(arg, false, false)

--- a/shortener.go
+++ b/shortener.go
@@ -455,9 +455,7 @@ func (s *Shortener) formatStmt(stmt dst.Stmt) {
 	case *dst.ExprStmt:
 		s.formatExpr(st.X, shouldShorten, false)
 	case *dst.ForStmt:
-		if !s.config.IgnoreBeforeIndentChange {
-			s.formatStmt(st.Body)
-		}
+		s.formatStmt(st.Body)
 	case *dst.GoStmt:
 		s.formatExpr(st.Call, shouldShorten, false)
 	case *dst.IfStmt:

--- a/shortener.go
+++ b/shortener.go
@@ -455,7 +455,9 @@ func (s *Shortener) formatStmt(stmt dst.Stmt) {
 	case *dst.ExprStmt:
 		s.formatExpr(st.X, shouldShorten, false)
 	case *dst.ForStmt:
-		s.formatStmt(st.Body)
+		if !s.config.IgnoreBeforeIndentChange {
+			s.formatStmt(st.Body)
+		}
 	case *dst.GoStmt:
 		s.formatExpr(st.Call, shouldShorten, false)
 	case *dst.IfStmt:


### PR DESCRIPTION
Added `ignore-indent-change` flag. When this flag is used, the line lengths of lines preceding an indentation change are ignored and exempted from shortening. When this flag is enabled, the following types of lines are impacted:
- `if` statements
- `for` statements
- `switch`, `select`, and `case` statements
- function and method declaration
- interface methods

This option allows for the use of `golines` while still conforming to the [Google Go style guide](https://google.github.io/styleguide/go/guide#line-length) guidelines for line length which say that a line should not be split before a change in indentation.

It is also worth noting that most of this functionality is already present in `golines` and I only needed to add code to modify how functions and methods, case calluses, and interface methods are handled for shortening.

Feature fix for #151