### PR TITLE
Updated REAME instructions for goland usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ let g:go_fmt_options = {
    - __Program:__ `golines`
    - __Arguments:__ `$FilePath$ -w`
    - __Output paths to refresh:__ `$FilePath$`
-4. In the "Advanced Options" section uncheck the __Auto-save edited files to trigger the watcher__ setting
-5. Confirm by clicking OK
-6. Activate your newly created file watcher in the Goland settings under "Tools" -> "Actions on save"
+3. In the "Advanced Options" section uncheck the __Auto-save edited files to trigger the watcher__ setting
+4. Confirm by clicking OK
+5. Activate your newly created file watcher in the Goland settings under "Tools" -> "Actions on save"
 
 ### Others
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,15 @@ let g:go_fmt_options = {
 ### Goland
 
 1. Go into the Goland settings and click "Tools" -> "File Watchers" then click the plus to create a new file watcher
-2. Set the following properties and confirm by clicking OK:
+2. Set the following properties:
    - __Name:__ `golines`
    - __File type:__ `Go files`
    - __Scope:__ `Project Files`
    - __Program:__ `golines`
    - __Arguments:__ `$FilePath$ -w`
    - __Output paths to refresh:__ `$FilePath$`
+4. In the "Advanced Options" section uncheck the __Auto-save edited files to trigger the watcher__ setting
+5. Confirm by clicking OK
 3. Activate your newly created file watcher in the Goland settings under "Tools" -> "Actions on save"
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ let g:go_fmt_options = {
    - __Output paths to refresh:__ `$FilePath$`
 4. In the "Advanced Options" section uncheck the __Auto-save edited files to trigger the watcher__ setting
 5. Confirm by clicking OK
-3. Activate your newly created file watcher in the Goland settings under "Tools" -> "Actions on save"
+6. Activate your newly created file watcher in the Goland settings under "Tools" -> "Actions on save"
 
 ### Others
 


### PR DESCRIPTION
Tried following to goland instructions and it was unusable as-is because golines is triggered constantly, causing formatting changes mid-type and removing whitespace right after you add it, before you had an opportunity to start typing on a line.

Unchecking a specific checkbox that is checked by default fixes this issue.