### PR TITLE
simplify tests; enable testifylint, usetesting linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 linters:
+  enable:
+    - testifylint
+    - usetesting
   disable:
     - errcheck
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -13,5 +13,5 @@ func TestPrettyDiff(t *testing.T) {
 		[]byte("line 1\nline 2"),
 		[]byte("line 1\nline 2 modified"),
 	)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -41,11 +42,11 @@ digraph {
 
 func TestCreateDot(t *testing.T) {
 	node, err := decorator.Parse(testCode)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	out := &bytes.Buffer{}
 	err = CreateDot(node, out)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, strings.TrimSpace(expDot), out.String())
 }


### PR DESCRIPTION
This PR simplifies tests by applying suggestions from [`testifylint`](https://golangci-lint.run/usage/linters/#testifylint) and [`usetesting`](https://golangci-lint.run/usage/linters/#usetesting) linters.