### PR TITLE
fix: go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/segmentio/golines
 
-go 1.23.0
+go 1.23
+
+toolchain go1.24.5
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
This PR fixes a go version issue in downstream consumers. Public API is unable to build its golang client due to an invalid go version.

https://buildkite.com/segment/public-api/builds/12754#0198de86-cb9f-4742-b45e-e444333ec3f8/321-340

Testing: no test needed

Validation: 
- ensure golines build succeeds
- ensure PAPI build works

Rollback:
Revert this PR and merge 